### PR TITLE
Fixes initial set of color

### DIFF
--- a/scss/pack/seed-color-fn/_config.scss
+++ b/scss/pack/seed-color-fn/_config.scss
@@ -1,4 +1,7 @@
 // Color :: Config
 
-// Empty by default
-$seed-color-scheme: () !global;
+// Default color scheme map
+$seed-color-scheme: (
+  black: "#000",
+  white: "#fff"
+) !global;

--- a/scss/pack/seed-color-fn/mixins/_color.scss
+++ b/scss/pack/seed-color-fn/mixins/_color.scss
@@ -4,6 +4,14 @@
 @import "../functions/_extend";
 
 @mixin _color($maps...) {
+  // Default map
+  $scheme: $seed-color-scheme;
+  // Reset if invalid
+  @if (type-of($scheme) != "map") {
+    $scheme: (
+      black: "#000"
+    );
+  }
   // Quietly set the color-scheme
-  $seed-color-scheme: _extend($seed-color-scheme, $maps...) !global;
+  $seed-color-scheme: _extend($scheme, $maps...) !global;
 }

--- a/test/mixins/_color.scss
+++ b/test/mixins/_color.scss
@@ -12,6 +12,21 @@ $seed-color-scheme: (
 
 @include test-module("Mixin: _color") {
 
+  @include test("should correctly handle initial blank color scheme") {
+
+    $seed-color-scheme: () !global;
+    $map: (
+      blue: blue
+    );
+
+    @include _color($map);
+
+    $test: _color(blue);
+    $expect: blue;
+
+    @include assert-equal($test, $expect, "blue");
+  }
+
   @include test("should correctly add a simple map") {
 
     $map: (


### PR DESCRIPTION
Sets the default color scheme to have `black` and `white` keys to allow the `_color` mixin to extend correctly.